### PR TITLE
UI: Reset USB device info view when selecting a new USB device

### DIFF
--- a/include/listview.h
+++ b/include/listview.h
@@ -55,6 +55,7 @@ public:
 	void CursorDown();
 	void CursorUp();
 	void Select();
+	void ResetCursor();
 	
 	void SetFocus(bool enableFocus);
 	void ToggleFocus(void) { SetFocus(! focused_); }

--- a/src/libui/listview.cpp
+++ b/src/libui/listview.cpp
@@ -243,3 +243,9 @@ void ListView::SetFocus(bool enableFocus)
 	}
 #endif	
 }
+
+void ListView::ResetCursor()
+{
+	current_index_ = 0;
+	start_index_ = 0;
+}

--- a/src/mainview.cpp
+++ b/src/mainview.cpp
@@ -83,7 +83,9 @@ void mainview::scroll_up()
 		m_devices_idx = m_UsbDevices_ListView.getCurrentIndex();
 		std::vector<std::string> usbdevinfo;
 		m_usb_ctx->getUsbDeviceInfo(m_devices_idx, usbdevinfo);
+		m_UsbDeviceInfo_ListView.ResetCursor();
 		m_UsbDeviceInfo_ListView.SetItems(usbdevinfo);
+		m_UsbDeviceInfo_ListView.Refresh();
 	}
 
 	m_UsbDeviceInfo_ListView.CursorUp();
@@ -94,10 +96,13 @@ void mainview::scroll_down()
 	m_UsbDevices_ListView.CursorDown();
 
 	if (m_UsbDevices_ListView.IsFocused()) {
+		// Update specific device info pane
 		m_devices_idx = m_UsbDevices_ListView.getCurrentIndex();
 		std::vector<std::string> usbdevinfo;
 		m_usb_ctx->getUsbDeviceInfo(m_devices_idx, usbdevinfo);
+		m_UsbDeviceInfo_ListView.ResetCursor();
 		m_UsbDeviceInfo_ListView.SetItems(usbdevinfo);
+		m_UsbDeviceInfo_ListView.Refresh();
 	}
 	m_UsbDeviceInfo_ListView.CursorDown();
 }


### PR DESCRIPTION
When selecting a new USB device from the list pane (on the left), the highlighted line
in the description pane (on the right) stayed at previous position.
It is now reset to top of pane.

Signed-off-by: Gilles Talis <gilles.talis@nxp.com>